### PR TITLE
Fix editor works pagination

### DIFF
--- a/src/lib/apollo.ts
+++ b/src/lib/apollo.ts
@@ -16,6 +16,8 @@ const client = new ApolloClient({
       Query: {
         fields: {
           ListReplies: relayStylePagination(['filter']),
+          ListReplyRequests: relayStylePagination(['filter']),
+          ListArticleReplyFeedbacks: relayStylePagination(['filter']),
         },
       },
     },

--- a/src/pages/EditorWorks/FeedbackTable.tsx
+++ b/src/pages/EditorWorks/FeedbackTable.tsx
@@ -158,6 +158,7 @@ const ReplyTable: React.FC<Props> = ({ startDate, endDate }) => {
     error,
     fetchMore,
   } = useFeedbackListInFeedbackTableQuery({
+    notifyOnNetworkStatusChange: true,
     variables: {
       pageSize: PAGE_SIZE,
       createdAt: createdAtFilter,
@@ -184,6 +185,7 @@ const ReplyTable: React.FC<Props> = ({ startDate, endDate }) => {
   };
 
   const edges = data?.ListArticleReplyFeedbacks?.edges || [];
+  const isLoading = loading || statLoading;
   return (
     <DataGrid
       rows={edges.map(({ node }) => node)}
@@ -196,7 +198,8 @@ const ReplyTable: React.FC<Props> = ({ startDate, endDate }) => {
       paginationMode="server"
       rowsPerPageOptions={[]}
       onPageChange={handlePageChange}
-      loading={loading || statLoading}
+      loading={isLoading}
+      hideFooterPagination={isLoading}
     />
   );
 };

--- a/src/pages/EditorWorks/ReplyRequestTable.tsx
+++ b/src/pages/EditorWorks/ReplyRequestTable.tsx
@@ -101,6 +101,7 @@ const ReplyTable: React.FC<Props> = ({ startDate, endDate }) => {
     error,
     fetchMore,
   } = useReplyRequestListInReplyRequestTableQuery({
+    notifyOnNetworkStatusChange: true,
     variables: {
       pageSize: PAGE_SIZE,
       createdAt: createdAtFilter,
@@ -127,6 +128,7 @@ const ReplyTable: React.FC<Props> = ({ startDate, endDate }) => {
   };
 
   const edges = data?.ListReplyRequests?.edges || [];
+  const isLoading = loading || statLoading;
   return (
     <DataGrid
       rows={edges.map(({ node }) => node)}
@@ -139,7 +141,8 @@ const ReplyTable: React.FC<Props> = ({ startDate, endDate }) => {
       paginationMode="server"
       rowsPerPageOptions={[]}
       onPageChange={handlePageChange}
-      loading={loading || statLoading}
+      loading={isLoading}
+      hideFooterPagination={isLoading}
     />
   );
 };

--- a/src/pages/EditorWorks/ReplyTable.tsx
+++ b/src/pages/EditorWorks/ReplyTable.tsx
@@ -108,6 +108,7 @@ const ReplyTable: React.FC<Props> = ({ startDate, endDate }) => {
     variables: { createdAt: createdAtFilter },
   });
   const { data, loading, error, fetchMore } = useReplyListInReplyTableQuery({
+    notifyOnNetworkStatusChange: true,
     variables: {
       pageSize: PAGE_SIZE,
       createdAt: createdAtFilter,
@@ -134,6 +135,7 @@ const ReplyTable: React.FC<Props> = ({ startDate, endDate }) => {
   };
 
   const edges = data?.ListReplies?.edges || [];
+  const isLoading = loading || statLoading;
   return (
     <DataGrid
       rows={edges.map(({ node }) => node)}
@@ -146,7 +148,8 @@ const ReplyTable: React.FC<Props> = ({ startDate, endDate }) => {
       paginationMode="server"
       rowsPerPageOptions={[]}
       onPageChange={handlePageChange}
-      loading={loading || statLoading}
+      loading={isLoading}
+      hideFooterPagination={isLoading}
     />
   );
 };


### PR DESCRIPTION
Fixes pagination of Feedbacks & Comments page under Editor Works.

- It is fixed by applying relay style pagination to `ListReplyRequests` and `ListArticleReplyFeedbacks`.
- This consolidates `fetchMore` results into the same filter, causing `edges.length` to grow correctly after `fetchMore` returns
- Hide pagination buttons when `fetchMore` so that `DataGrid`'s page stat can match component's max page loading state

## Screenshot

List of feedback: can go to next page now.
![paginate](https://user-images.githubusercontent.com/108608/148018720-7ad4df14-ddc9-45e7-9008-fc629a7141a8.gif)

This also applies to "comments".