### PR TITLE
[EditorWorks] add userId support

### DIFF
--- a/src/pages/EditorWorks/EditorWorks.tsx
+++ b/src/pages/EditorWorks/EditorWorks.tsx
@@ -1,4 +1,5 @@
-import React, { useState } from 'react';
+import React from 'react';
+import { useLocation, useHistory } from 'react-router-dom';
 import Paper from '@material-ui/core/Paper';
 import Card from '@material-ui/core/Card';
 import CardContent from '@material-ui/core/CardContent';
@@ -27,10 +28,41 @@ enum WorkType {
   REPLY_REQUEST,
 }
 
+type ParamsFromUrl = Readonly<{
+  workType: WorkType;
+  day: number;
+  userId?: string;
+}>;
+
+type GoFn = (p: ParamsFromUrl) => void;
+
+function useUrlParams(): [ParamsFromUrl, GoFn] {
+  const { search, pathname } = useLocation();
+  const { push } = useHistory();
+  const searchParams = new URLSearchParams(search);
+
+  return [
+    {
+      workType: +(searchParams.get('type') ?? WorkType.REPLY),
+      day: +(searchParams.get('day') ?? 7),
+      userId: searchParams.get('userId') || undefined,
+    },
+    (p) => {
+      const query = new URLSearchParams({
+        type: p.workType.toString(),
+        day: p.day.toString(),
+        ...(p.userId ? { userId: p.userId } : {}),
+      });
+      push(`${pathname}?${query}`);
+    },
+  ];
+}
+
 const EditorWorks: React.FC = () => {
   const classes = useStyles();
-  const [workType, setWorkType] = useState<WorkType>(WorkType.REPLY);
-  const [day, setDay] = useState<number>(7);
+  const [param, go] = useUrlParams();
+  // eslint-disable-next-line no-console
+  console.log('param', param);
 
   return (
     <>
@@ -38,8 +70,8 @@ const EditorWorks: React.FC = () => {
         <CardContent classes={{ root: classes.controlContent }}>
           <TextField
             select
-            value={workType}
-            onChange={(e): void => setWorkType(+e.target.value)}
+            value={param.workType}
+            onChange={(e): void => go({ ...param, workType: +e.target.value })}
           >
             <MenuItem value={WorkType.REPLY}>Replies</MenuItem>
             <MenuItem value={WorkType.ARTICLE_REPLY_FEEDBACK}>
@@ -50,19 +82,35 @@ const EditorWorks: React.FC = () => {
           in the last{' '}
           <input
             type="number"
-            defaultValue={day}
-            onBlur={(e) => setDay(+e.target.value)}
+            defaultValue={param.day}
+            onBlur={(e) => go({ ...param, day: +e.target.value })}
           />{' '}
           days
+          {param.userId && (
+            <span>
+              for user{' '}
+              <a
+                href={`${process.env.REACT_APP_SITE_URL}/user?id=${param.userId}`}
+              >
+                {param.userId}
+              </a>
+            </span>
+          )}
         </CardContent>
       </Card>
       <Paper style={{ height: 700 }}>
-        {workType === WorkType.REPLY ? (
-          <ReplyTable startDate={`now-${day}d`} />
-        ) : workType === WorkType.ARTICLE_REPLY_FEEDBACK ? (
-          <FeedbackTable startDate={`now-${day}d`} />
-        ) : workType === WorkType.REPLY_REQUEST ? (
-          <ReplyRequestTable startDate={`now-${day}d`} />
+        {param.workType === WorkType.REPLY ? (
+          <ReplyTable startDate={`now-${param.day}d`} userId={param.userId} />
+        ) : param.workType === WorkType.ARTICLE_REPLY_FEEDBACK ? (
+          <FeedbackTable
+            startDate={`now-${param.day}d`}
+            userId={param.userId}
+          />
+        ) : param.workType === WorkType.REPLY_REQUEST ? (
+          <ReplyRequestTable
+            startDate={`now-${param.day}d`}
+            userId={param.userId}
+          />
         ) : null}
       </Paper>
     </>

--- a/src/pages/EditorWorks/FeedbackTable.graphql
+++ b/src/pages/EditorWorks/FeedbackTable.graphql
@@ -1,6 +1,10 @@
-query FeedbackListStatInFeedbackTable($createdAt: TimeRangeInput, $userId: String) {
+query FeedbackListStatInFeedbackTable(
+  $createdAt: TimeRangeInput
+  $userId: String
+  $statuses: [ArticleReplyFeedbackStatusEnum!]
+) {
   ListArticleReplyFeedbacks(
-    filter: { createdAt: $createdAt, userId: $userId }
+    filter: { createdAt: $createdAt, userId: $userId, statuses: $statuses }
   ) {
     totalCount
     pageInfo {
@@ -10,7 +14,13 @@ query FeedbackListStatInFeedbackTable($createdAt: TimeRangeInput, $userId: Strin
   }
 }
 
-query FeedbackListInFeedbackTable($after: String, $pageSize: Int, $createdAt: TimeRangeInput, $userId: String) {
+query FeedbackListInFeedbackTable(
+  $after: String
+  $pageSize: Int
+  $createdAt: TimeRangeInput
+  $userId: String
+  $statuses: [ArticleReplyFeedbackStatusEnum!]
+) {
   ListArticleReplyFeedbacks(
     filter: { createdAt: $createdAt, userId: $userId }
     orderBy: [{ createdAt: DESC }]

--- a/src/pages/EditorWorks/FeedbackTable.graphql
+++ b/src/pages/EditorWorks/FeedbackTable.graphql
@@ -1,6 +1,6 @@
-query FeedbackListStatInFeedbackTable($createdAt: TimeRangeInput) {
+query FeedbackListStatInFeedbackTable($createdAt: TimeRangeInput, $userId: String) {
   ListArticleReplyFeedbacks(
-    filter: { createdAt: $createdAt }
+    filter: { createdAt: $createdAt, userId: $userId }
   ) {
     totalCount
     pageInfo {
@@ -10,9 +10,9 @@ query FeedbackListStatInFeedbackTable($createdAt: TimeRangeInput) {
   }
 }
 
-query FeedbackListInFeedbackTable($after: String, $pageSize: Int, $createdAt: TimeRangeInput) {
+query FeedbackListInFeedbackTable($after: String, $pageSize: Int, $createdAt: TimeRangeInput, $userId: String) {
   ListArticleReplyFeedbacks(
-    filter: { createdAt: $createdAt }
+    filter: { createdAt: $createdAt, userId: $userId }
     orderBy: [{ createdAt: DESC }]
     after: $after
     first: $pageSize

--- a/src/pages/EditorWorks/FeedbackTable.tsx
+++ b/src/pages/EditorWorks/FeedbackTable.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { styled } from '@material-ui/core/styles';
 import Link from '@material-ui/core/Link';
+import { Link as RRLink } from 'react-router-dom';
 import Typography from '@material-ui/core/Typography';
 import DataTable, { PAGE_SIZE } from '../../components/DataTable';
 import { GridColDef } from '@mui/x-data-grid';
@@ -46,15 +47,7 @@ const COLUMNS: GridColDef[] = [
     renderCell(params) {
       const user = params.getValue(params.id, 'user') as User;
       if (!user) return <div />;
-      return (
-        <Link
-          href={`${process.env.REACT_APP_SITE_URL}/user?id=${user.id}`}
-          color="textPrimary"
-          variant="body2"
-        >
-          {user.name}
-        </Link>
-      );
+      return <RRLink to={`?userId=${user.id}`}>{user.name}</RRLink>;
     },
   },
   {
@@ -132,9 +125,10 @@ type Props = {
   startDate?: string;
   /** Elasticsearch supported time string */
   endDate?: string;
+  userId?: string;
 };
 
-const ReplyTable: React.FC<Props> = ({ startDate, endDate }) => {
+const ReplyTable: React.FC<Props> = ({ startDate, endDate, userId }) => {
   const createdAtFilter = {
     GTE: startDate,
     LTE: endDate,
@@ -145,7 +139,7 @@ const ReplyTable: React.FC<Props> = ({ startDate, endDate }) => {
     loading: statLoading,
     error: statError,
   } = useFeedbackListStatInFeedbackTableQuery({
-    variables: { createdAt: createdAtFilter },
+    variables: { createdAt: createdAtFilter, userId },
   });
   const {
     data,
@@ -157,6 +151,7 @@ const ReplyTable: React.FC<Props> = ({ startDate, endDate }) => {
     variables: {
       pageSize: PAGE_SIZE,
       createdAt: createdAtFilter,
+      userId,
     },
   });
 

--- a/src/pages/EditorWorks/ReplyRequestTable.graphql
+++ b/src/pages/EditorWorks/ReplyRequestTable.graphql
@@ -1,6 +1,10 @@
-query ReplyRequestListStatInReplyRequestTable($createdAt: TimeRangeInput, $userId: String) {
+query ReplyRequestListStatInReplyRequestTable(
+  $createdAt: TimeRangeInput
+  $userId: String
+  $statuses: [ReplyRequestStatusEnum!]
+) {
   ListReplyRequests(
-    filter: { createdAt: $createdAt, userId: $userId }
+    filter: { createdAt: $createdAt, userId: $userId, statuses: $statuses }
   ) {
     totalCount
     pageInfo {
@@ -10,9 +14,15 @@ query ReplyRequestListStatInReplyRequestTable($createdAt: TimeRangeInput, $userI
   }
 }
 
-query ReplyRequestListInReplyRequestTable($after: String, $pageSize: Int, $createdAt: TimeRangeInput, $userId: String) {
+query ReplyRequestListInReplyRequestTable(
+  $after: String
+  $pageSize: Int
+  $createdAt: TimeRangeInput
+  $userId: String
+  $statuses: [ReplyRequestStatusEnum!]
+) {
   ListReplyRequests(
-    filter: { createdAt: $createdAt, userId: $userId }
+    filter: { createdAt: $createdAt, userId: $userId, statuses: $statuses }
     orderBy: [{ createdAt: DESC }]
     after: $after
     first: $pageSize

--- a/src/pages/EditorWorks/ReplyRequestTable.graphql
+++ b/src/pages/EditorWorks/ReplyRequestTable.graphql
@@ -1,6 +1,6 @@
-query ReplyRequestListStatInReplyRequestTable($createdAt: TimeRangeInput) {
+query ReplyRequestListStatInReplyRequestTable($createdAt: TimeRangeInput, $userId: String) {
   ListReplyRequests(
-    filter: { createdAt: $createdAt }
+    filter: { createdAt: $createdAt, userId: $userId }
   ) {
     totalCount
     pageInfo {
@@ -10,9 +10,9 @@ query ReplyRequestListStatInReplyRequestTable($createdAt: TimeRangeInput) {
   }
 }
 
-query ReplyRequestListInReplyRequestTable($after: String, $pageSize: Int, $createdAt: TimeRangeInput) {
+query ReplyRequestListInReplyRequestTable($after: String, $pageSize: Int, $createdAt: TimeRangeInput, $userId: String) {
   ListReplyRequests(
-    filter: { createdAt: $createdAt }
+    filter: { createdAt: $createdAt, userId: $userId }
     orderBy: [{ createdAt: DESC }]
     after: $after
     first: $pageSize

--- a/src/pages/EditorWorks/ReplyRequestTable.tsx
+++ b/src/pages/EditorWorks/ReplyRequestTable.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { styled } from '@material-ui/core/styles';
-import Link from '@material-ui/core/Link';
+import { Link as RRLink } from 'react-router-dom';
 import DataTable, { PAGE_SIZE } from '../../components/DataTable';
 import { GridColDef } from '@mui/x-data-grid';
 
@@ -36,15 +36,7 @@ const COLUMNS: GridColDef[] = [
     renderCell(params) {
       const user = params.getValue(params.id, 'user') as User;
       if (!user) return <div />;
-      return (
-        <Link
-          href={`${process.env.REACT_APP_SITE_URL}/user?id=${user.id}`}
-          color="textPrimary"
-          variant="body2"
-        >
-          {user.name}
-        </Link>
-      );
+      return <RRLink to={`?userId=${user.id}`}>{user.name}</RRLink>;
     },
   },
   {
@@ -76,9 +68,10 @@ type Props = {
   startDate?: string;
   /** Elasticsearch supported time string */
   endDate?: string;
+  userId?: string;
 };
 
-const ReplyTable: React.FC<Props> = ({ startDate, endDate }) => {
+const ReplyTable: React.FC<Props> = ({ startDate, endDate, userId }) => {
   const createdAtFilter = {
     GTE: startDate,
     LTE: endDate,
@@ -89,7 +82,7 @@ const ReplyTable: React.FC<Props> = ({ startDate, endDate }) => {
     loading: statLoading,
     error: statError,
   } = useReplyRequestListStatInReplyRequestTableQuery({
-    variables: { createdAt: createdAtFilter },
+    variables: { createdAt: createdAtFilter, userId },
   });
   const {
     data,
@@ -101,6 +94,7 @@ const ReplyTable: React.FC<Props> = ({ startDate, endDate }) => {
     variables: {
       pageSize: PAGE_SIZE,
       createdAt: createdAtFilter,
+      userId,
     },
   });
 

--- a/src/pages/EditorWorks/ReplyTable.graphql
+++ b/src/pages/EditorWorks/ReplyTable.graphql
@@ -1,6 +1,6 @@
-query ReplyListStatInReplyTable($createdAt: TimeRangeInput) {
+query ReplyListStatInReplyTable($createdAt: TimeRangeInput, $userId: String) {
   ListReplies(
-    filter: { createdAt: $createdAt }
+    filter: { createdAt: $createdAt, userId: $userId }
   ) {
     totalCount
     pageInfo {
@@ -10,9 +10,9 @@ query ReplyListStatInReplyTable($createdAt: TimeRangeInput) {
   }
 }
 
-query ReplyListInReplyTable($after: String, $pageSize: Int, $createdAt: TimeRangeInput) {
+query ReplyListInReplyTable($after: String, $pageSize: Int, $createdAt: TimeRangeInput, $userId: String) {
   ListReplies(
-    filter: { createdAt: $createdAt }
+    filter: { createdAt: $createdAt, userId: $userId }
     orderBy: [{ createdAt: DESC }]
     after: $after
     first: $pageSize

--- a/src/pages/EditorWorks/ReplyTable.tsx
+++ b/src/pages/EditorWorks/ReplyTable.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { styled } from '@material-ui/core/styles';
 import Link from '@material-ui/core/Link';
+import { Link as RRLink } from 'react-router-dom';
 import DataTable, { PAGE_SIZE } from '../../components/DataTable';
 import { GridColDef } from '@mui/x-data-grid';
 
@@ -36,15 +37,7 @@ const COLUMNS: GridColDef[] = [
     renderCell(params) {
       const user = params.getValue(params.id, 'user') as User;
       if (!user) return <div />;
-      return (
-        <Link
-          href={`${process.env.REACT_APP_SITE_URL}/user?id=${user.id}`}
-          color="textPrimary"
-          variant="body2"
-        >
-          {user.name}
-        </Link>
-      );
+      return <RRLink to={`?userId=${user.id}`}>{user.name}</RRLink>;
     },
   },
   {
@@ -88,9 +81,10 @@ type Props = {
   startDate?: string;
   /** Elasticsearch supported time string */
   endDate?: string;
+  userId?: string;
 };
 
-const ReplyTable: React.FC<Props> = ({ startDate, endDate }) => {
+const ReplyTable: React.FC<Props> = ({ startDate, endDate, userId }) => {
   const createdAtFilter = {
     GTE: startDate,
     LTE: endDate,
@@ -101,13 +95,14 @@ const ReplyTable: React.FC<Props> = ({ startDate, endDate }) => {
     loading: statLoading,
     error: statError,
   } = useReplyListStatInReplyTableQuery({
-    variables: { createdAt: createdAtFilter },
+    variables: { createdAt: createdAtFilter, userId },
   });
   const { data, loading, error, fetchMore } = useReplyListInReplyTableQuery({
     notifyOnNetworkStatusChange: true,
     variables: {
       pageSize: PAGE_SIZE,
       createdAt: createdAtFilter,
+      userId,
     },
   });
 

--- a/src/pages/EditorWorks/ReplyTable.tsx
+++ b/src/pages/EditorWorks/ReplyTable.tsx
@@ -4,6 +4,7 @@ import Link from '@material-ui/core/Link';
 import { Link as RRLink } from 'react-router-dom';
 import DataTable, { PAGE_SIZE } from '../../components/DataTable';
 import { GridColDef } from '@mui/x-data-grid';
+import { getSearchString, WorkType } from './util';
 
 import {
   useReplyListInReplyTableQuery,
@@ -37,7 +38,18 @@ const COLUMNS: GridColDef[] = [
     renderCell(params) {
       const user = params.getValue(params.id, 'user') as User;
       if (!user) return <div />;
-      return <RRLink to={`?userId=${user.id}`}>{user.name}</RRLink>;
+      return (
+        <RRLink
+          to={`?${getSearchString({
+            workType: WorkType.REPLY,
+            day: 7,
+            userId: user.id,
+            showAll: true,
+          })}`}
+        >
+          {user.name}
+        </RRLink>
+      );
     },
   },
   {

--- a/src/pages/EditorWorks/util.ts
+++ b/src/pages/EditorWorks/util.ts
@@ -1,0 +1,56 @@
+import { useLocation, useHistory } from 'react-router-dom';
+
+export enum WorkType {
+  REPLY,
+  ARTICLE_REPLY_FEEDBACK,
+  REPLY_REQUEST,
+}
+
+/**
+ * Parameters to store in URL search string for editor works page
+ */
+type ParamsFromUrl = Readonly<{
+  workType: WorkType;
+  day: number;
+  userId?: string;
+  showAll?: boolean;
+}>;
+
+/**
+ * Goes to the URL specified by `p`.
+ */
+type GoFn = (p: ParamsFromUrl) => void;
+
+/**
+ * @param p
+ * @returns URLSearchParams instance for the given params
+ */
+export function getSearchString(p: ParamsFromUrl): URLSearchParams {
+  return new URLSearchParams({
+    type: p.workType.toString(),
+    day: p.day.toString(),
+    ...(p.userId ? { userId: p.userId } : {}),
+    ...(p.showAll ? { showAll: '1' } : {}),
+  });
+}
+
+/**
+ * Retrieves the current params from search string, and a function to navigate to new params
+ */
+export function useUrlParams(): [ParamsFromUrl, GoFn] {
+  const { search, pathname } = useLocation();
+  const { push } = useHistory();
+  const searchParams = new URLSearchParams(search);
+
+  return [
+    {
+      workType: +(searchParams.get('type') ?? WorkType.REPLY),
+      day: +(searchParams.get('day') ?? 7),
+      userId: searchParams.get('userId') || undefined,
+      showAll: !!searchParams.get('showAll'),
+    },
+    (p) => {
+      push(`${pathname}?${getSearchString(p)}`);
+    },
+  ];
+}

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -1067,6 +1067,7 @@ export type BigNumOfFeedbacksQuery = (
 export type FeedbackListStatInFeedbackTableQueryVariables = Exact<{
   createdAt?: Maybe<TimeRangeInput>;
   userId?: Maybe<Scalars['String']>;
+  statuses?: Maybe<ReadonlyArray<ArticleReplyFeedbackStatusEnum>>;
 }>;
 
 
@@ -1087,6 +1088,7 @@ export type FeedbackListInFeedbackTableQueryVariables = Exact<{
   pageSize?: Maybe<Scalars['Int']>;
   createdAt?: Maybe<TimeRangeInput>;
   userId?: Maybe<Scalars['String']>;
+  statuses?: Maybe<ReadonlyArray<ArticleReplyFeedbackStatusEnum>>;
 }>;
 
 
@@ -1118,6 +1120,7 @@ export type FeedbackListInFeedbackTableQuery = (
 export type ReplyRequestListStatInReplyRequestTableQueryVariables = Exact<{
   createdAt?: Maybe<TimeRangeInput>;
   userId?: Maybe<Scalars['String']>;
+  statuses?: Maybe<ReadonlyArray<ReplyRequestStatusEnum>>;
 }>;
 
 
@@ -1138,6 +1141,7 @@ export type ReplyRequestListInReplyRequestTableQueryVariables = Exact<{
   pageSize?: Maybe<Scalars['Int']>;
   createdAt?: Maybe<TimeRangeInput>;
   userId?: Maybe<Scalars['String']>;
+  statuses?: Maybe<ReadonlyArray<ReplyRequestStatusEnum>>;
 }>;
 
 
@@ -1311,8 +1315,8 @@ export type BigNumOfFeedbacksQueryHookResult = ReturnType<typeof useBigNumOfFeed
 export type BigNumOfFeedbacksLazyQueryHookResult = ReturnType<typeof useBigNumOfFeedbacksLazyQuery>;
 export type BigNumOfFeedbacksQueryResult = Apollo.QueryResult<BigNumOfFeedbacksQuery, BigNumOfFeedbacksQueryVariables>;
 export const FeedbackListStatInFeedbackTableDocument = gql`
-    query FeedbackListStatInFeedbackTable($createdAt: TimeRangeInput, $userId: String) {
-  ListArticleReplyFeedbacks(filter: {createdAt: $createdAt, userId: $userId}) {
+    query FeedbackListStatInFeedbackTable($createdAt: TimeRangeInput, $userId: String, $statuses: [ArticleReplyFeedbackStatusEnum!]) {
+  ListArticleReplyFeedbacks(filter: {createdAt: $createdAt, userId: $userId, statuses: $statuses}) {
     totalCount
     pageInfo {
       firstCursor
@@ -1336,6 +1340,7 @@ export const FeedbackListStatInFeedbackTableDocument = gql`
  *   variables: {
  *      createdAt: // value for 'createdAt'
  *      userId: // value for 'userId'
+ *      statuses: // value for 'statuses'
  *   },
  * });
  */
@@ -1349,7 +1354,7 @@ export type FeedbackListStatInFeedbackTableQueryHookResult = ReturnType<typeof u
 export type FeedbackListStatInFeedbackTableLazyQueryHookResult = ReturnType<typeof useFeedbackListStatInFeedbackTableLazyQuery>;
 export type FeedbackListStatInFeedbackTableQueryResult = Apollo.QueryResult<FeedbackListStatInFeedbackTableQuery, FeedbackListStatInFeedbackTableQueryVariables>;
 export const FeedbackListInFeedbackTableDocument = gql`
-    query FeedbackListInFeedbackTable($after: String, $pageSize: Int, $createdAt: TimeRangeInput, $userId: String) {
+    query FeedbackListInFeedbackTable($after: String, $pageSize: Int, $createdAt: TimeRangeInput, $userId: String, $statuses: [ArticleReplyFeedbackStatusEnum!]) {
   ListArticleReplyFeedbacks(filter: {createdAt: $createdAt, userId: $userId}, orderBy: [{createdAt: DESC}], after: $after, first: $pageSize) {
     edges {
       cursor
@@ -1392,6 +1397,7 @@ export const FeedbackListInFeedbackTableDocument = gql`
  *      pageSize: // value for 'pageSize'
  *      createdAt: // value for 'createdAt'
  *      userId: // value for 'userId'
+ *      statuses: // value for 'statuses'
  *   },
  * });
  */
@@ -1405,8 +1411,8 @@ export type FeedbackListInFeedbackTableQueryHookResult = ReturnType<typeof useFe
 export type FeedbackListInFeedbackTableLazyQueryHookResult = ReturnType<typeof useFeedbackListInFeedbackTableLazyQuery>;
 export type FeedbackListInFeedbackTableQueryResult = Apollo.QueryResult<FeedbackListInFeedbackTableQuery, FeedbackListInFeedbackTableQueryVariables>;
 export const ReplyRequestListStatInReplyRequestTableDocument = gql`
-    query ReplyRequestListStatInReplyRequestTable($createdAt: TimeRangeInput, $userId: String) {
-  ListReplyRequests(filter: {createdAt: $createdAt, userId: $userId}) {
+    query ReplyRequestListStatInReplyRequestTable($createdAt: TimeRangeInput, $userId: String, $statuses: [ReplyRequestStatusEnum!]) {
+  ListReplyRequests(filter: {createdAt: $createdAt, userId: $userId, statuses: $statuses}) {
     totalCount
     pageInfo {
       firstCursor
@@ -1430,6 +1436,7 @@ export const ReplyRequestListStatInReplyRequestTableDocument = gql`
  *   variables: {
  *      createdAt: // value for 'createdAt'
  *      userId: // value for 'userId'
+ *      statuses: // value for 'statuses'
  *   },
  * });
  */
@@ -1443,8 +1450,8 @@ export type ReplyRequestListStatInReplyRequestTableQueryHookResult = ReturnType<
 export type ReplyRequestListStatInReplyRequestTableLazyQueryHookResult = ReturnType<typeof useReplyRequestListStatInReplyRequestTableLazyQuery>;
 export type ReplyRequestListStatInReplyRequestTableQueryResult = Apollo.QueryResult<ReplyRequestListStatInReplyRequestTableQuery, ReplyRequestListStatInReplyRequestTableQueryVariables>;
 export const ReplyRequestListInReplyRequestTableDocument = gql`
-    query ReplyRequestListInReplyRequestTable($after: String, $pageSize: Int, $createdAt: TimeRangeInput, $userId: String) {
-  ListReplyRequests(filter: {createdAt: $createdAt, userId: $userId}, orderBy: [{createdAt: DESC}], after: $after, first: $pageSize) {
+    query ReplyRequestListInReplyRequestTable($after: String, $pageSize: Int, $createdAt: TimeRangeInput, $userId: String, $statuses: [ReplyRequestStatusEnum!]) {
+  ListReplyRequests(filter: {createdAt: $createdAt, userId: $userId, statuses: $statuses}, orderBy: [{createdAt: DESC}], after: $after, first: $pageSize) {
     edges {
       cursor
       node {
@@ -1477,6 +1484,7 @@ export const ReplyRequestListInReplyRequestTableDocument = gql`
  *      pageSize: // value for 'pageSize'
  *      createdAt: // value for 'createdAt'
  *      userId: // value for 'userId'
+ *      statuses: // value for 'statuses'
  *   },
  * });
  */

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -1066,6 +1066,7 @@ export type BigNumOfFeedbacksQuery = (
 
 export type FeedbackListStatInFeedbackTableQueryVariables = Exact<{
   createdAt?: Maybe<TimeRangeInput>;
+  userId?: Maybe<Scalars['String']>;
 }>;
 
 
@@ -1085,6 +1086,7 @@ export type FeedbackListInFeedbackTableQueryVariables = Exact<{
   after?: Maybe<Scalars['String']>;
   pageSize?: Maybe<Scalars['Int']>;
   createdAt?: Maybe<TimeRangeInput>;
+  userId?: Maybe<Scalars['String']>;
 }>;
 
 
@@ -1115,6 +1117,7 @@ export type FeedbackListInFeedbackTableQuery = (
 
 export type ReplyRequestListStatInReplyRequestTableQueryVariables = Exact<{
   createdAt?: Maybe<TimeRangeInput>;
+  userId?: Maybe<Scalars['String']>;
 }>;
 
 
@@ -1134,6 +1137,7 @@ export type ReplyRequestListInReplyRequestTableQueryVariables = Exact<{
   after?: Maybe<Scalars['String']>;
   pageSize?: Maybe<Scalars['Int']>;
   createdAt?: Maybe<TimeRangeInput>;
+  userId?: Maybe<Scalars['String']>;
 }>;
 
 
@@ -1158,6 +1162,7 @@ export type ReplyRequestListInReplyRequestTableQuery = (
 
 export type ReplyListStatInReplyTableQueryVariables = Exact<{
   createdAt?: Maybe<TimeRangeInput>;
+  userId?: Maybe<Scalars['String']>;
 }>;
 
 
@@ -1177,6 +1182,7 @@ export type ReplyListInReplyTableQueryVariables = Exact<{
   after?: Maybe<Scalars['String']>;
   pageSize?: Maybe<Scalars['Int']>;
   createdAt?: Maybe<TimeRangeInput>;
+  userId?: Maybe<Scalars['String']>;
 }>;
 
 
@@ -1305,8 +1311,8 @@ export type BigNumOfFeedbacksQueryHookResult = ReturnType<typeof useBigNumOfFeed
 export type BigNumOfFeedbacksLazyQueryHookResult = ReturnType<typeof useBigNumOfFeedbacksLazyQuery>;
 export type BigNumOfFeedbacksQueryResult = Apollo.QueryResult<BigNumOfFeedbacksQuery, BigNumOfFeedbacksQueryVariables>;
 export const FeedbackListStatInFeedbackTableDocument = gql`
-    query FeedbackListStatInFeedbackTable($createdAt: TimeRangeInput) {
-  ListArticleReplyFeedbacks(filter: {createdAt: $createdAt}) {
+    query FeedbackListStatInFeedbackTable($createdAt: TimeRangeInput, $userId: String) {
+  ListArticleReplyFeedbacks(filter: {createdAt: $createdAt, userId: $userId}) {
     totalCount
     pageInfo {
       firstCursor
@@ -1329,6 +1335,7 @@ export const FeedbackListStatInFeedbackTableDocument = gql`
  * const { data, loading, error } = useFeedbackListStatInFeedbackTableQuery({
  *   variables: {
  *      createdAt: // value for 'createdAt'
+ *      userId: // value for 'userId'
  *   },
  * });
  */
@@ -1342,8 +1349,8 @@ export type FeedbackListStatInFeedbackTableQueryHookResult = ReturnType<typeof u
 export type FeedbackListStatInFeedbackTableLazyQueryHookResult = ReturnType<typeof useFeedbackListStatInFeedbackTableLazyQuery>;
 export type FeedbackListStatInFeedbackTableQueryResult = Apollo.QueryResult<FeedbackListStatInFeedbackTableQuery, FeedbackListStatInFeedbackTableQueryVariables>;
 export const FeedbackListInFeedbackTableDocument = gql`
-    query FeedbackListInFeedbackTable($after: String, $pageSize: Int, $createdAt: TimeRangeInput) {
-  ListArticleReplyFeedbacks(filter: {createdAt: $createdAt}, orderBy: [{createdAt: DESC}], after: $after, first: $pageSize) {
+    query FeedbackListInFeedbackTable($after: String, $pageSize: Int, $createdAt: TimeRangeInput, $userId: String) {
+  ListArticleReplyFeedbacks(filter: {createdAt: $createdAt, userId: $userId}, orderBy: [{createdAt: DESC}], after: $after, first: $pageSize) {
     edges {
       cursor
       node {
@@ -1384,6 +1391,7 @@ export const FeedbackListInFeedbackTableDocument = gql`
  *      after: // value for 'after'
  *      pageSize: // value for 'pageSize'
  *      createdAt: // value for 'createdAt'
+ *      userId: // value for 'userId'
  *   },
  * });
  */
@@ -1397,8 +1405,8 @@ export type FeedbackListInFeedbackTableQueryHookResult = ReturnType<typeof useFe
 export type FeedbackListInFeedbackTableLazyQueryHookResult = ReturnType<typeof useFeedbackListInFeedbackTableLazyQuery>;
 export type FeedbackListInFeedbackTableQueryResult = Apollo.QueryResult<FeedbackListInFeedbackTableQuery, FeedbackListInFeedbackTableQueryVariables>;
 export const ReplyRequestListStatInReplyRequestTableDocument = gql`
-    query ReplyRequestListStatInReplyRequestTable($createdAt: TimeRangeInput) {
-  ListReplyRequests(filter: {createdAt: $createdAt}) {
+    query ReplyRequestListStatInReplyRequestTable($createdAt: TimeRangeInput, $userId: String) {
+  ListReplyRequests(filter: {createdAt: $createdAt, userId: $userId}) {
     totalCount
     pageInfo {
       firstCursor
@@ -1421,6 +1429,7 @@ export const ReplyRequestListStatInReplyRequestTableDocument = gql`
  * const { data, loading, error } = useReplyRequestListStatInReplyRequestTableQuery({
  *   variables: {
  *      createdAt: // value for 'createdAt'
+ *      userId: // value for 'userId'
  *   },
  * });
  */
@@ -1434,8 +1443,8 @@ export type ReplyRequestListStatInReplyRequestTableQueryHookResult = ReturnType<
 export type ReplyRequestListStatInReplyRequestTableLazyQueryHookResult = ReturnType<typeof useReplyRequestListStatInReplyRequestTableLazyQuery>;
 export type ReplyRequestListStatInReplyRequestTableQueryResult = Apollo.QueryResult<ReplyRequestListStatInReplyRequestTableQuery, ReplyRequestListStatInReplyRequestTableQueryVariables>;
 export const ReplyRequestListInReplyRequestTableDocument = gql`
-    query ReplyRequestListInReplyRequestTable($after: String, $pageSize: Int, $createdAt: TimeRangeInput) {
-  ListReplyRequests(filter: {createdAt: $createdAt}, orderBy: [{createdAt: DESC}], after: $after, first: $pageSize) {
+    query ReplyRequestListInReplyRequestTable($after: String, $pageSize: Int, $createdAt: TimeRangeInput, $userId: String) {
+  ListReplyRequests(filter: {createdAt: $createdAt, userId: $userId}, orderBy: [{createdAt: DESC}], after: $after, first: $pageSize) {
     edges {
       cursor
       node {
@@ -1467,6 +1476,7 @@ export const ReplyRequestListInReplyRequestTableDocument = gql`
  *      after: // value for 'after'
  *      pageSize: // value for 'pageSize'
  *      createdAt: // value for 'createdAt'
+ *      userId: // value for 'userId'
  *   },
  * });
  */
@@ -1480,8 +1490,8 @@ export type ReplyRequestListInReplyRequestTableQueryHookResult = ReturnType<type
 export type ReplyRequestListInReplyRequestTableLazyQueryHookResult = ReturnType<typeof useReplyRequestListInReplyRequestTableLazyQuery>;
 export type ReplyRequestListInReplyRequestTableQueryResult = Apollo.QueryResult<ReplyRequestListInReplyRequestTableQuery, ReplyRequestListInReplyRequestTableQueryVariables>;
 export const ReplyListStatInReplyTableDocument = gql`
-    query ReplyListStatInReplyTable($createdAt: TimeRangeInput) {
-  ListReplies(filter: {createdAt: $createdAt}) {
+    query ReplyListStatInReplyTable($createdAt: TimeRangeInput, $userId: String) {
+  ListReplies(filter: {createdAt: $createdAt, userId: $userId}) {
     totalCount
     pageInfo {
       firstCursor
@@ -1504,6 +1514,7 @@ export const ReplyListStatInReplyTableDocument = gql`
  * const { data, loading, error } = useReplyListStatInReplyTableQuery({
  *   variables: {
  *      createdAt: // value for 'createdAt'
+ *      userId: // value for 'userId'
  *   },
  * });
  */
@@ -1517,8 +1528,8 @@ export type ReplyListStatInReplyTableQueryHookResult = ReturnType<typeof useRepl
 export type ReplyListStatInReplyTableLazyQueryHookResult = ReturnType<typeof useReplyListStatInReplyTableLazyQuery>;
 export type ReplyListStatInReplyTableQueryResult = Apollo.QueryResult<ReplyListStatInReplyTableQuery, ReplyListStatInReplyTableQueryVariables>;
 export const ReplyListInReplyTableDocument = gql`
-    query ReplyListInReplyTable($after: String, $pageSize: Int, $createdAt: TimeRangeInput) {
-  ListReplies(filter: {createdAt: $createdAt}, orderBy: [{createdAt: DESC}], after: $after, first: $pageSize) {
+    query ReplyListInReplyTable($after: String, $pageSize: Int, $createdAt: TimeRangeInput, $userId: String) {
+  ListReplies(filter: {createdAt: $createdAt, userId: $userId}, orderBy: [{createdAt: DESC}], after: $after, first: $pageSize) {
     edges {
       cursor
       node {
@@ -1550,6 +1561,7 @@ export const ReplyListInReplyTableDocument = gql`
  *      after: // value for 'after'
  *      pageSize: // value for 'pageSize'
  *      createdAt: // value for 'createdAt'
+ *      userId: // value for 'userId'
  *   },
  * });
  */


### PR DESCRIPTION
- `userId` can be provided from URL and lists items from such user only
- clicking user name in tables will display the user's work in the last 7 days
- pass `showAll=1` in URL to display blocked content as well
- Refactor: now work type, day, userId and showAll settings are controlled by search string in URL

## Lists blocked contents of a specific user
Passing `showAll=1` and the user ID in the URL to show all contents for a specific user
<img width="962" alt="圖片" src="https://user-images.githubusercontent.com/108608/151117337-5531f4fe-2b91-46ce-8f0e-ce8dc0aa041a.png">


