### PR TITLE
Add columns and filters in editor works tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Other scripts include:
 - `npm run lint`: Runs eslint
 - `npm run lint:fix`: Runs eslint and handle fixable errors
 - `npm run typecheck`: Checks Typescript types
+- `npm run codegen`: After changing GraphQL query, run this to update Typescript types
 
 Lint and check is also invoked in Travis.
 

--- a/src/pages/EditorWorks/EditorWorks.tsx
+++ b/src/pages/EditorWorks/EditorWorks.tsx
@@ -59,6 +59,17 @@ const EditorWorks: React.FC = () => {
               </a>
             </span>
           )}
+          {param.articleReplyUserId &&
+            param.workType === WorkType.ARTICLE_REPLY_FEEDBACK && (
+              <span>
+                for article reply user{' '}
+                <a
+                  href={`${process.env.REACT_APP_SITE_URL}/user?id=${param.articleReplyUserId}`}
+                >
+                  {param.articleReplyUserId}
+                </a>
+              </span>
+            )}
         </CardContent>
       </Card>
       <Paper style={{ height: 700 }}>
@@ -68,6 +79,7 @@ const EditorWorks: React.FC = () => {
           <FeedbackTable
             startDate={`now-${param.day}d`}
             userId={param.userId}
+            articleReplyUserId={param.articleReplyUserId}
             showAll={param.showAll}
           />
         ) : param.workType === WorkType.REPLY_REQUEST ? (

--- a/src/pages/EditorWorks/FeedbackTable.graphql
+++ b/src/pages/EditorWorks/FeedbackTable.graphql
@@ -1,10 +1,16 @@
 query FeedbackListStatInFeedbackTable(
   $createdAt: TimeRangeInput
   $userId: String
+  $articleReplyUserId: String
   $statuses: [ArticleReplyFeedbackStatusEnum!]
 ) {
   ListArticleReplyFeedbacks(
-    filter: { createdAt: $createdAt, userId: $userId, statuses: $statuses }
+    filter: {
+      createdAt: $createdAt
+      userId: $userId
+      articleReplyUserId: $articleReplyUserId
+      statuses: $statuses
+    }
   ) {
     totalCount
     pageInfo {
@@ -19,10 +25,16 @@ query FeedbackListInFeedbackTable(
   $pageSize: Int
   $createdAt: TimeRangeInput
   $userId: String
+  $articleReplyUserId: String
   $statuses: [ArticleReplyFeedbackStatusEnum!]
 ) {
   ListArticleReplyFeedbacks(
-    filter: { createdAt: $createdAt, userId: $userId, statuses: $statuses }
+    filter: {
+      createdAt: $createdAt
+      userId: $userId
+      articleReplyUserId: $articleReplyUserId
+      statuses: $statuses
+    }
     orderBy: [{ createdAt: DESC }]
     after: $after
     first: $pageSize

--- a/src/pages/EditorWorks/FeedbackTable.graphql
+++ b/src/pages/EditorWorks/FeedbackTable.graphql
@@ -36,6 +36,11 @@ query FeedbackListInFeedbackTable(
         article {
           id
           text
+          articleCategories(statuses: [NORMAL]) {
+            category { title }
+            positiveFeedbackCount
+            negativeFeedbackCount
+          }
         }
         reply {
           id

--- a/src/pages/EditorWorks/FeedbackTable.tsx
+++ b/src/pages/EditorWorks/FeedbackTable.tsx
@@ -194,6 +194,7 @@ type Props = {
   /** Elasticsearch supported time string */
   endDate?: string;
   userId?: string;
+  articleReplyUserId?: string;
   /** Also shows BLOCKED feedbacks if true */
   showAll?: boolean;
 };
@@ -202,6 +203,7 @@ const ReplyTable: React.FC<Props> = ({
   startDate,
   endDate,
   userId,
+  articleReplyUserId,
   showAll,
 }) => {
   const createdAtFilter = {
@@ -215,7 +217,12 @@ const ReplyTable: React.FC<Props> = ({
     loading: statLoading,
     error: statError,
   } = useFeedbackListStatInFeedbackTableQuery({
-    variables: { createdAt: createdAtFilter, userId, statuses },
+    variables: {
+      createdAt: createdAtFilter,
+      userId,
+      articleReplyUserId,
+      statuses,
+    },
   });
   const {
     data,
@@ -228,6 +235,7 @@ const ReplyTable: React.FC<Props> = ({
       pageSize: PAGE_SIZE,
       createdAt: createdAtFilter,
       userId,
+      articleReplyUserId,
       statuses,
     },
   });

--- a/src/pages/EditorWorks/FeedbackTable.tsx
+++ b/src/pages/EditorWorks/FeedbackTable.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { styled } from '@material-ui/core/styles';
+import Chip from '@material-ui/core/Chip';
 import Link from '@material-ui/core/Link';
 import { Link as RRLink } from 'react-router-dom';
 import Typography from '@material-ui/core/Typography';
@@ -30,6 +31,25 @@ type Reply = NonNullable<
 type CreatedAt = NonNullable<
   FeedbackListInFeedbackTableQuery['ListArticleReplyFeedbacks']
 >['edges'][number]['node']['createdAt'];
+
+type ArticleCategory = NonNullable<
+  NonNullable<Article>['articleCategories']
+>[number];
+
+type ValidArticleCategory = NonNullable<ArticleCategory> & {
+  category: NonNullable<NonNullable<ArticleCategory>['category']>;
+};
+
+function isValidArticleCategory(
+  ar: ArticleCategory
+): ar is ValidArticleCategory {
+  return (
+    !!ar &&
+    typeof ar.positiveFeedbackCount === 'number' &&
+    typeof ar.negativeFeedbackCount === 'number' &&
+    ar.positiveFeedbackCount >= ar.negativeFeedbackCount
+  );
+}
 
 const TextCell = styled('div')({
   width: '100%',
@@ -90,7 +110,7 @@ const COLUMNS: GridColDef[] = [
   {
     field: 'target',
     headerName: 'Article & Reply',
-    width: 480,
+    width: 300,
     renderCell(params) {
       const article = params.getValue(params.id, 'article') as Article;
       const reply = params.getValue(params.id, 'reply') as Reply;
@@ -102,7 +122,9 @@ const COLUMNS: GridColDef[] = [
               color="textPrimary"
               variant="body2"
             >
-              <Typography variant="body2">{article.text || ''}</Typography>
+              <Typography variant="body2" title={article.text || ''}>
+                {article.text || ''}
+              </Typography>
             </Link>
           )}
           {reply && (
@@ -111,7 +133,9 @@ const COLUMNS: GridColDef[] = [
               color="textPrimary"
               variant="body2"
             >
-              <Typography variant="body2">{reply.text || ''}</Typography>
+              <Typography variant="body2" title={reply.text || ''}>
+                {reply.text || ''}
+              </Typography>
             </Link>
           )}
         </div>
@@ -121,7 +145,7 @@ const COLUMNS: GridColDef[] = [
   {
     field: 'createdAt',
     headerName: 'Created At',
-    width: 200,
+    width: 175,
     valueGetter: (params) => {
       const createdAt = params.value as CreatedAt;
       if (!createdAt) {
@@ -129,6 +153,31 @@ const COLUMNS: GridColDef[] = [
       }
 
       return new Date(createdAt).toLocaleString();
+    },
+  },
+  {
+    field: 'categories',
+    headerName: 'Article category',
+    width: 240,
+    renderCell(params) {
+      const article = params.getValue(params.id, 'article') as Article;
+      const categories = (article?.articleCategories || []).filter(
+        isValidArticleCategory
+      );
+      if (categories.length === 0) return '';
+
+      return (
+        <TextCell>
+          {categories.map(({ category }, idx) => (
+            <Chip
+              size="small"
+              key={idx}
+              label={category.title}
+              style={{ margin: ' 0 1px 1px 0' }}
+            />
+          ))}
+        </TextCell>
+      );
     },
   },
 ];

--- a/src/pages/EditorWorks/ReplyRequestTable.graphql
+++ b/src/pages/EditorWorks/ReplyRequestTable.graphql
@@ -37,6 +37,10 @@ query ReplyRequestListInReplyRequestTable(
           id
           name
         }
+        article {
+          id
+          text
+        }
       }
     }
   }

--- a/src/pages/EditorWorks/ReplyRequestTable.tsx
+++ b/src/pages/EditorWorks/ReplyRequestTable.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { styled } from '@material-ui/core/styles';
+import Link from '@material-ui/core/Link';
 import { Link as RRLink } from 'react-router-dom';
+import Typography from '@material-ui/core/Typography';
 import DataTable, { PAGE_SIZE } from '../../components/DataTable';
 import { GridColDef } from '@mui/x-data-grid';
 import { getSearchString, WorkType } from './util';
@@ -19,6 +21,10 @@ type User = NonNullable<
 type UpdatedAt = NonNullable<
   ReplyRequestListInReplyRequestTableQuery['ListReplyRequests']
 >['edges'][number]['node']['updatedAt'];
+
+type Article = NonNullable<
+  ReplyRequestListInReplyRequestTableQuery['ListReplyRequests']
+>['edges'][number]['node']['article'];
 
 const TextCell = styled('div')({
   width: '100%',
@@ -59,6 +65,25 @@ const COLUMNS: GridColDef[] = [
     renderCell(params) {
       const reason = params.value;
       return <TextCell>{reason}</TextCell>;
+    },
+  },
+  {
+    field: 'article',
+    headerName: 'Article',
+    width: 300,
+    renderCell(params) {
+      const { id, text } = params.value as Article;
+      return (
+        <TextCell>
+          <Link
+            href={`${process.env.REACT_APP_SITE_URL}/article/${id}`}
+            color="textPrimary"
+            variant="body2"
+          >
+            <Typography variant="body2">{text || ''}</Typography>
+          </Link>
+        </TextCell>
+      );
     },
   },
   {

--- a/src/pages/EditorWorks/util.ts
+++ b/src/pages/EditorWorks/util.ts
@@ -13,6 +13,8 @@ type ParamsFromUrl = Readonly<{
   workType: WorkType;
   day: number;
   userId?: string;
+  /** For feedback list. Lists feedbacks for a specific creator of article replies. */
+  articleReplyUserId?: string;
   showAll?: boolean;
 }>;
 
@@ -30,6 +32,9 @@ export function getSearchString(p: ParamsFromUrl): URLSearchParams {
     type: p.workType.toString(),
     day: p.day.toString(),
     ...(p.userId ? { userId: p.userId } : {}),
+    ...(p.articleReplyUserId
+      ? { articleReplyUserId: p.articleReplyUserId }
+      : {}),
     ...(p.showAll ? { showAll: '1' } : {}),
   });
 }
@@ -47,6 +52,7 @@ export function useUrlParams(): [ParamsFromUrl, GoFn] {
       workType: +(searchParams.get('type') ?? WorkType.REPLY),
       day: +(searchParams.get('day') ?? 7),
       userId: searchParams.get('userId') || undefined,
+      articleReplyUserId: searchParams.get('articleReplyUserId') || undefined,
       showAll: !!searchParams.get('showAll'),
     },
     (p) => {

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -1150,6 +1150,14 @@ export type FeedbackListInFeedbackTableQuery = (
         & { readonly article?: Maybe<(
           { readonly __typename?: 'Article' }
           & Pick<Article, 'id' | 'text'>
+          & { readonly articleCategories?: Maybe<ReadonlyArray<Maybe<(
+            { readonly __typename?: 'ArticleCategory' }
+            & Pick<ArticleCategory, 'positiveFeedbackCount' | 'negativeFeedbackCount'>
+            & { readonly category?: Maybe<(
+              { readonly __typename?: 'Category' }
+              & Pick<Category, 'title'>
+            )> }
+          )>>> }
         )>, readonly reply?: Maybe<(
           { readonly __typename?: 'Reply' }
           & Pick<Reply, 'id' | 'text'>
@@ -1413,6 +1421,13 @@ export const FeedbackListInFeedbackTableDocument = gql`
         article {
           id
           text
+          articleCategories(statuses: [NORMAL]) {
+            category {
+              title
+            }
+            positiveFeedbackCount
+            negativeFeedbackCount
+          }
         }
         reply {
           id

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -137,6 +137,12 @@ export type Article = Node & {
   readonly hyperlinks?: Maybe<ReadonlyArray<Maybe<Hyperlink>>>;
   /** Activities analytics for the given article */
   readonly stats?: Maybe<ReadonlyArray<Maybe<Analytics>>>;
+  /** Message event type */
+  readonly articleType: ArticleTypeEnum;
+  /** Attachment of this article */
+  readonly attachmentUrl?: Maybe<Scalars['String']>;
+  /** Attachment hash to search or identify files */
+  readonly attachmentHash?: Maybe<Scalars['String']>;
 };
 
 
@@ -633,7 +639,24 @@ export type Analytics = {
   readonly webVisit?: Maybe<Scalars['Int']>;
 };
 
+export enum ArticleTypeEnum {
+  Text = 'TEXT',
+  Image = 'IMAGE',
+  Video = 'VIDEO',
+  Audio = 'AUDIO'
+}
+
 export type ListArticleFilter = {
+  /** Show only articles created by a specific app. */
+  readonly appId?: Maybe<Scalars['String']>;
+  /** Show only articles created by the specific user. */
+  readonly userId?: Maybe<Scalars['String']>;
+  /** List only the articles that were created between the specific time range. */
+  readonly createdAt?: Maybe<TimeRangeInput>;
+  /** If given, only list out articles with specific IDs */
+  readonly ids?: Maybe<ReadonlyArray<Scalars['ID']>>;
+  /** Only list the articles created by the currently logged in user */
+  readonly selfOnly?: Maybe<Scalars['Boolean']>;
   /** List only the articles whose number of replies matches the criteria. */
   readonly replyCount?: Maybe<RangeInput>;
   /** List only the articles whose number of categories match the criteria. */
@@ -644,18 +667,9 @@ export type ListArticleFilter = {
   readonly moreLikeThis?: Maybe<MoreLikeThisInput>;
   /** List only the articles whose number of replies matches the criteria. */
   readonly replyRequestCount?: Maybe<RangeInput>;
-  /** List only the articles that were created between the specific time range. */
-  readonly createdAt?: Maybe<TimeRangeInput>;
   /** List only the articles that were replied between the specific time range. */
   readonly repliedAt?: Maybe<TimeRangeInput>;
-  /** Show only articles from a specific user. */
-  readonly appId?: Maybe<Scalars['String']>;
-  /** Show only articles from a specific user. */
-  readonly userId?: Maybe<Scalars['String']>;
-  /**
-   * Specify an articleId here to show only articles from the sender of that specified article.
-   * When specified, it overrides the settings of appId and userId.
-   */
+  /** Specify an articleId here to show only articles from the sender of that specified article. */
   readonly fromUserOfArticleId?: Maybe<Scalars['String']>;
   /** Show only articles with(out) article replies created by specified user */
   readonly articleRepliesFrom?: Maybe<UserAndExistInput>;
@@ -667,6 +681,10 @@ export type ListArticleFilter = {
   readonly hasArticleReplyWithMorePositiveFeedback?: Maybe<Scalars['Boolean']>;
   /** List the articles with replies of certain types */
   readonly replyTypes?: Maybe<ReadonlyArray<Maybe<ReplyTypeEnum>>>;
+  /** List the articles with certain types */
+  readonly articleTypes?: Maybe<ReadonlyArray<Maybe<ArticleTypeEnum>>>;
+  /** Show the media article similar to the input url */
+  readonly mediaUrl?: Maybe<Scalars['String']>;
 };
 
 /**
@@ -704,17 +722,21 @@ export type ListArticleOrderBy = {
 };
 
 export type ListReplyFilter = {
-  readonly userId?: Maybe<Scalars['String']>;
+  /** Show only replies created by a specific app. */
   readonly appId?: Maybe<Scalars['String']>;
-  readonly moreLikeThis?: Maybe<MoreLikeThisInput>;
-  /** List the replies created by the requester themselves */
+  /** Show only replies created by the specific user. */
+  readonly userId?: Maybe<Scalars['String']>;
+  /** List only the replies that were created between the specific time range. */
+  readonly createdAt?: Maybe<TimeRangeInput>;
+  /** If given, only list out replies with specific IDs */
+  readonly ids?: Maybe<ReadonlyArray<Scalars['ID']>>;
+  /** Only list the replies created by the currently logged in user */
   readonly selfOnly?: Maybe<Scalars['Boolean']>;
+  readonly moreLikeThis?: Maybe<MoreLikeThisInput>;
   /** [Deprecated] use types instead. */
   readonly type?: Maybe<ReplyTypeEnum>;
   /** List the replies of certain types */
   readonly types?: Maybe<ReadonlyArray<Maybe<ReplyTypeEnum>>>;
-  /** List only the replies that were created between the specific time range. */
-  readonly createdAt?: Maybe<TimeRangeInput>;
 };
 
 /** An entry of orderBy argument. Specifies field name and the sort order. Only one field name is allowd per entry. */
@@ -773,16 +795,22 @@ export type ListArticleReplyFeedbackConnectionPageInfo = PageInfo & {
 };
 
 export type ListArticleReplyFeedbackFilter = {
-  readonly userId?: Maybe<Scalars['String']>;
+  /** Show only article reply feedbacks created by a specific app. */
   readonly appId?: Maybe<Scalars['String']>;
+  /** Show only article reply feedbacks created by the specific user. */
+  readonly userId?: Maybe<Scalars['String']>;
+  /** List only the article reply feedbacks that were created between the specific time range. */
+  readonly createdAt?: Maybe<TimeRangeInput>;
+  /** If given, only list out article reply feedbacks with specific IDs */
+  readonly ids?: Maybe<ReadonlyArray<Scalars['ID']>>;
+  /** Only list the article reply feedbacks created by the currently logged in user */
+  readonly selfOnly?: Maybe<Scalars['Boolean']>;
   readonly articleId?: Maybe<Scalars['String']>;
   readonly replyId?: Maybe<Scalars['String']>;
   /** Search for comment field using more_like_this query */
   readonly moreLikeThis?: Maybe<MoreLikeThisInput>;
   /** When specified, list only article reply feedbacks with specified vote */
   readonly vote?: Maybe<ReadonlyArray<Maybe<FeedbackVote>>>;
-  /** List only the article reply feedbacks that were created within the specific time range. */
-  readonly createdAt?: Maybe<TimeRangeInput>;
   /** List only the article reply feedbacks that were last updated within the specific time range. */
   readonly updatedAt?: Maybe<TimeRangeInput>;
   /** List only the article reply feedbacks with the selected statuses */
@@ -821,10 +849,17 @@ export type ListReplyRequestConnectionPageInfo = PageInfo & {
 };
 
 export type ListReplyRequestFilter = {
-  readonly userId?: Maybe<Scalars['String']>;
+  /** Show only reply requests created by a specific app. */
   readonly appId?: Maybe<Scalars['String']>;
-  readonly articleId?: Maybe<Scalars['String']>;
+  /** Show only reply requests created by the specific user. */
+  readonly userId?: Maybe<Scalars['String']>;
+  /** List only the reply requests that were created between the specific time range. */
   readonly createdAt?: Maybe<TimeRangeInput>;
+  /** If given, only list out reply requests with specific IDs */
+  readonly ids?: Maybe<ReadonlyArray<Scalars['ID']>>;
+  /** Only list the reply requests created by the currently logged in user */
+  readonly selfOnly?: Maybe<Scalars['Boolean']>;
+  readonly articleId?: Maybe<Scalars['String']>;
   /** List only reply requests with specified statuses */
   readonly statuses?: Maybe<ReadonlyArray<ReplyRequestStatusEnum>>;
 };
@@ -889,6 +924,8 @@ export type Mutation = {
   readonly __typename?: 'Mutation';
   /** Create an article and/or a replyRequest */
   readonly CreateArticle?: Maybe<MutationResult>;
+  /** Create a media article and/or a replyRequest */
+  readonly CreateMediaArticle?: Maybe<MutationResult>;
   /** Create a reply that replies to the specified article. */
   readonly CreateReply?: Maybe<MutationResult>;
   /** Connects specified reply and specified article. */
@@ -921,6 +958,14 @@ export type Mutation = {
 
 export type MutationCreateArticleArgs = {
   text: Scalars['String'];
+  reference: ArticleReferenceInput;
+  reason?: Maybe<Scalars['String']>;
+};
+
+
+export type MutationCreateMediaArticleArgs = {
+  mediaUrl: Scalars['String'];
+  articleType: ArticleTypeEnum;
   reference: ArticleReferenceInput;
   reason?: Maybe<Scalars['String']>;
 };
@@ -1158,7 +1203,10 @@ export type ReplyRequestListInReplyRequestTableQuery = (
         & { readonly user?: Maybe<(
           { readonly __typename?: 'User' }
           & Pick<User, 'id' | 'name'>
-        )> }
+        )>, readonly article: (
+          { readonly __typename?: 'Article' }
+          & Pick<Article, 'id' | 'text'>
+        ) }
       ) }
     )> }
   )> }
@@ -1461,6 +1509,10 @@ export const ReplyRequestListInReplyRequestTableDocument = gql`
         user {
           id
           name
+        }
+        article {
+          id
+          text
         }
       }
     }


### PR DESCRIPTION
This PR depends on API being released to production https://github.com/cofacts/rumors-api/pull/286 and feedback user IDs being [fully migrated](https://github.com/cofacts/rumors-api/pull/285#issuecomment-1159399583).

## Add category column in feedback table
Lists the article's category for each feedback.
Fixes #11

<img width="1280" alt="圖片" src="https://user-images.githubusercontent.com/108608/175810778-0344ac0f-c7df-4a31-95a1-d355a6cee866.png">

## Show feedbacks for a specific article-reply creator
Introduces `articleReplyUserId` URL param that specifies the author of article replies.
Fixes #10 

<img width="1400" alt="圖片" src="https://user-images.githubusercontent.com/108608/175810802-ee011c98-2b4a-489f-b45a-e4c51557fe54.png">

## Add article text for reply request
This helps when we determine if a user-reported spamming reply request is replying to something relevant.
Also it provides link to article so that we can click into it to see if there is other spamming comments.

<img width="1215" alt="圖片" src="https://user-images.githubusercontent.com/108608/175810744-26db3e31-a030-4466-aec4-d1f1865b7fae.png">
