### PR TITLE
[BigNum] add comment count

### DIFF
--- a/src/pages/BigNum.tsx
+++ b/src/pages/BigNum.tsx
@@ -6,12 +6,13 @@ import { makeStyles } from '@material-ui/core/styles';
 import { isSomeEnum } from '../lib/util';
 import FUN_NUMBERS from '../lib/funNumbers';
 
-const MARGIN = 80;
+const MARGIN = 8;
 const POLLING_INTERVAL = 5000;
 
 export enum PanelType {
   replied = 'replied',
   feedback = 'feedback',
+  comment = 'comment',
 }
 
 /**
@@ -47,7 +48,20 @@ const PANELS_SETUP = {
     query: gql`
       query BigNumOfFeedbacks($startTime: String) {
         query: ListArticleReplyFeedbacks(
-          filter: { createdAt: { GTE: $startTime } }
+          filter: { createdAt: { GTE: $startTime }, appId: "WEBSITE" }
+        ) {
+          totalCount
+        }
+      }
+    `,
+  },
+  [PanelType.comment]: {
+    top: '新增了',
+    bottom: '則補充',
+    query: gql`
+      query BigNumOfComments($startTime: String) {
+        query: ListReplyRequests(
+          filter: { createdAt: { GTE: $startTime }, appId: "WEBSITE" }
         ) {
           totalCount
         }

--- a/src/pages/BigNumSetup.tsx
+++ b/src/pages/BigNumSetup.tsx
@@ -60,21 +60,31 @@ const BigNumSetup: React.FC = () => {
               control={
                 <Checkbox
                   name="panels"
-                  value={PanelType.replied}
-                  defaultChecked
-                />
-              }
-              label="Replied articles"
-            />
-            <FormControlLabel
-              control={
-                <Checkbox
-                  name="panels"
                   value={PanelType.feedback}
                   defaultChecked
                 />
               }
               label="Feedbacks"
+            />
+            <FormControlLabel
+              control={
+                <Checkbox
+                  name="panels"
+                  value={PanelType.comment}
+                  defaultChecked
+                />
+              }
+              label="Comments"
+            />
+            <FormControlLabel
+              control={
+                <Checkbox
+                  name="panels"
+                  value={PanelType.replied}
+                  defaultChecked
+                />
+              }
+              label="Replied articles"
             />
           </FormGroup>
         </CardContent>


### PR DESCRIPTION
- Add comment count panel
- Apply `website` filter to feedbacks and reply-requests so that numbers only show website user contributions
    - Better match the contributor on site
- Adjust order to feedback > comment > reply so that it corresponds to meetup's introductionary order

<img width="757" alt="image" src="https://user-images.githubusercontent.com/108608/192085333-b0bc0938-ee0e-4b49-a27b-2cec3b6396ae.png">

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/108608/192085307-c549a74a-3db9-48a1-88ca-06301a65df77.png">
