### PR TITLE
feat(ReplyRequestTable): show "audio" or "video" for audio/video

### DIFF
--- a/src/pages/EditorWorks/ReplyRequestTable.tsx
+++ b/src/pages/EditorWorks/ReplyRequestTable.tsx
@@ -92,6 +92,18 @@ const COLUMNS: GridColDef[] = [
                   ) : (
                     'Image'
                   );
+                case 'AUDIO':
+                  return (
+                    <Typography variant="body2" title={article.text || ''}>
+                      Audio
+                    </Typography>
+                  );
+                case 'VIDEO':
+                  return (
+                    <Typography variant="body2" title={article.text || ''}>
+                      Video
+                    </Typography>
+                  );
                 default:
                   return (
                     <Typography variant="body2" title={article.text || ''}>


### PR DESCRIPTION
So that even if video and audio have no thumbnail for now, they can show a link that brings user to the article page to see / hear the content.

<img width="1425" alt="image" src="https://user-images.githubusercontent.com/108608/218243641-66ed7fab-394b-4a27-82f4-af52ab8a1aac.png">
